### PR TITLE
Fix the crash on native

### DIFF
--- a/src/funkin/vis/dsp/Complex.hx
+++ b/src/funkin/vis/dsp/Complex.hx
@@ -3,7 +3,7 @@ package funkin.vis.dsp;
 /**
 	Complex number representation.
 **/
-@:forward(real, imag) @:notNull @:pure
+@:forward(real, imag) @:pure
 abstract Complex({
 	final real : Float;
 	final imag : Float;

--- a/src/funkin/vis/dsp/FFT.hx
+++ b/src/funkin/vis/dsp/FFT.hx
@@ -85,13 +85,15 @@ class FFT {
 
 	private static function ditfft4(time:Array<Complex>, t:Int, freq:Array<Complex>, f:Int, n:Int, step:Int, inverse:Bool):Void {
 		
-		if (n == 4) {
+		if (n == 2) {
 			// Base case: Compute the 4-point DFT directly
 			for (k in 0...n) {
 				var sum = Complex.zero;
 				for (j in 0...4) {
 					var twiddle = Complex.exp((inverse ? 1 : -1) * 2 * Math.PI * k / n); 
-					sum += time[t + j * step] * twiddle;
+					var index = t + j * step;
+					if(time[index] != null)
+						sum += time[index] * twiddle;
 				}
 				freq[f + k] = sum;
 			}


### PR DESCRIPTION
This does fix the crash but for some reason it gives incorrect frequency
i tried messing around alot and couldn't make it analyze better (i just suck at math)
here's a video of how it looks like in-game (ik it's terrible)
https://github.com/FunkinCrew/funkVis/assets/144803230/ffb6a63f-7e63-438e-a208-c3f9864c3780

i messed around with the math and got it to look like this (it's still terrible, but slightly better)
https://cdn.discordapp.com/attachments/1235540927070732392/1241078064700456971/2024-05-17_20-19-43.mp4?ex=664cd804&is=664b8684&hm=ab3998dcb785e3e0c982f197294eb761062da56d46b7fbadfadf7107926fc7bb&
i won't include what i made in this cuz it's a terrible workaround
yall knows better than me in FFT so i bet you'll get it to visualizer properly

