### PR TITLE
SoundInstance instead of fixed FlxG.sound.music

### DIFF
--- a/src/funkin/vis/audioclip/frontends/LimeAudioClip.hx
+++ b/src/funkin/vis/audioclip/frontends/LimeAudioClip.hx
@@ -2,29 +2,43 @@ package funkin.vis.audioclip.frontends;
 
 import flixel.FlxG;
 import flixel.math.FlxMath;
+import flixel.sound.FlxSound;
 import funkin.vis.AudioBuffer;
 import lime.media.AudioSource;
+import funkin.vis.dsp.SpectralAnalyzer;
 
 /**
  * Implementation of AudioClip for Lime.
  * On OpenFL you will want SoundChannel.__source (with @:privateAccess)
  * For Flixel, you will want to get the FlxSound._channel.__source
- * 
+ *
  * Note: On one of the recent OpenFL versions (9.3.2)
  * __source was renamed to __audioSource
  * https://github.com/openfl/openfl/commit/eec48a
- * 
+ *
  */
 class LimeAudioClip implements funkin.vis.AudioClip
 {
+	public var audioSource(default, null):AudioSource;
 	public var audioBuffer(default, null):AudioBuffer;
-    public var currentFrame(get, never):Int;
+	public var currentFrame(get, never):Int;
 	public var source:Dynamic;
+	public var soundInstance(default, set):FlxSound;
 
-	public function new(audioSource:AudioSource)
+	public function new(?soundInstance:FlxSound)
 	{
+		if (soundInstance == null)
+			this.soundInstance = FlxG.sound.music;
+		else
+			this.soundInstance = soundInstance;
+	}
+
+	function set_soundInstance(value:FlxSound):FlxSound
+	{
+		this.soundInstance = value;
+		this.audioSource = getSoundChannelSource(value);
 		var data:lime.utils.UInt16Array = cast audioSource.buffer.data;
-		
+
 		#if web
 		var sampleRate:Float = audioSource.buffer.src._sounds[0]._node.context.sampleRate;
 		#else
@@ -33,6 +47,8 @@ class LimeAudioClip implements funkin.vis.AudioClip
 
 		this.audioBuffer = new AudioBuffer(data, sampleRate);
 		this.source = audioSource.buffer.src;
+
+		return value;
 	}
 
 	private function get_currentFrame():Int
@@ -45,6 +61,25 @@ class LimeAudioClip implements funkin.vis.AudioClip
 		dataLength = audioBuffer.data.length;
 		#end
 
-		return Std.int(FlxMath.remapToRange(FlxG.sound.music.time, 0, FlxG.sound.music.length, 0, dataLength));
+		return Std.int(FlxMath.remapToRange(soundInstance.time, 0, soundInstance.length, 0, dataLength));
+	}
+
+	/**
+	 * Gets an FlxSound audio source, mainly used for visualisers.
+	 *
+	 * @param input The byte data.
+	 * @return The playable sound, or `null` if loading failed.
+	 */
+	public static function getSoundChannelSource(input:FlxSound):AudioSource
+	{
+	  #if (openfl < "9.3.2") @:privateAccess
+	  return input._channel.__source;
+	  // if (input._channel.__source != null)
+	  #else
+	  @:privateAccess
+	  return input._channel.__audioSource;
+	  // if (input._channel.__audioSource != null) return input._channel.__audioSource;
+	  #end
+	  return null;
 	}
 }

--- a/src/funkin/vis/dsp/SpectralAnalyzer.hx
+++ b/src/funkin/vis/dsp/SpectralAnalyzer.hx
@@ -2,6 +2,7 @@ package funkin.vis.dsp;
 
 import flixel.FlxG;
 import flixel.math.FlxMath;
+import flixel.sound.FlxSound;
 import funkin.vis._internal.html5.AnalyzerNode;
 import funkin.vis.audioclip.frontends.LimeAudioClip;
 import grig.audio.FFT;
@@ -40,9 +41,14 @@ class SpectralAnalyzer
     public var fftN(default, set):Int = 4096;
     public var minFreq:Float = 50;
     public var maxFreq:Float = 22000;
+	public var soundInstance(default, set):FlxSound;
     // Awkwardly, we'll have to interfaces for now because there's too much platform specific stuff we need
     private var audioSource:AudioSource;
+    #if lime
+    private var audioClip:LimeAudioClip;
+    #else
     private var audioClip:AudioClip;
+    #end
 	private var barCount:Int;
     private var maxDelta:Float;
     private var peakHold:Int;
@@ -141,10 +147,11 @@ class SpectralAnalyzer
         #end
     }
 
-	public function new(audioSource:AudioSource, barCount:Int, maxDelta:Float = 0.01, peakHold:Int = 30)
+	public function new(soundInstance:FlxSound, barCount:Int, maxDelta:Float = 0.01, peakHold:Int = 30)
 	{
-        this.audioSource = audioSource;
-		this.audioClip = new LimeAudioClip(audioSource);
+        this.soundInstance = soundInstance;
+		this.audioClip = new LimeAudioClip(soundInstance);
+        this.audioSource = this.audioSource;
 		this.barCount = barCount;
         this.maxDelta = maxDelta;
         this.peakHold = peakHold;
@@ -333,5 +340,16 @@ class SpectralAnalyzer
         calcBars(barCount, peakHold);
         resizeBlackmanWindow(fftN);
         return pow2;
+    }
+
+    function set_soundInstance(value:FlxSound):FlxSound
+    {
+        soundInstance = value;
+        if(audioClip != null)
+        {
+		    audioClip.soundInstance = soundInstance;
+            audioSource = audioSource;
+        }
+        return soundInstance;
     }
 }

--- a/src/funkin/vis/dsp/SpectralAnalyzer.hx
+++ b/src/funkin/vis/dsp/SpectralAnalyzer.hx
@@ -348,7 +348,7 @@ class SpectralAnalyzer
         if(audioClip != null)
         {
 		    audioClip.soundInstance = soundInstance;
-            audioSource = audioSource;
+            audioSource = audioClip.audioSource;
         }
         return soundInstance;
     }

--- a/src/funkin/vis/dsp/SpectralAnalyzer.hx
+++ b/src/funkin/vis/dsp/SpectralAnalyzer.hx
@@ -151,7 +151,7 @@ class SpectralAnalyzer
 	{
         this.soundInstance = soundInstance;
 		this.audioClip = new LimeAudioClip(soundInstance);
-        this.audioSource = this.audioSource;
+        this.audioSource = audioClip.audioSource;
 		this.barCount = barCount;
         this.maxDelta = maxDelta;
         this.peakHold = peakHold;


### PR DESCRIPTION
So currently LimeAudioClip only checks for the FlxG.sound.music time, but if we want a visualizer for an other sound instance... well it breaks...
So I changed the code to get the sound instance instead of the sound source... and allow to update the source without having to create a new visualiser from scratch.

(it also implies that you'll have to change the argument for SpectralAnalyzer from soundInstance._channel.__audioSource to soundInstance dirrectly)