### PR TITLE
Seperate DSP FFT from grig FFT in SpectralAnalyzer

### DIFF
--- a/src/funkin/vis/dsp/SpectralAnalyzer.hx
+++ b/src/funkin/vis/dsp/SpectralAnalyzer.hx
@@ -7,6 +7,7 @@ import funkin.vis.audioclip.frontends.LimeAudioClip;
 import grig.audio.FFT;
 import grig.audio.FFTVisualization;
 import lime.media.AudioSource;
+import funkin.vis.dsp.FFT as DspFFT;
 
 using grig.audio.lime.UInt8ArrayTools;
 
@@ -328,7 +329,7 @@ class SpectralAnalyzer
     function set_fftN(value:Int):Int
     {
         fftN = value;
-        var pow2 = FFT.nextPow2(value);
+        var pow2 = DspFFT.nextPow2(value);
         fftN2 = Std.int(pow2 / 2);
 
         #if web


### PR DESCRIPTION
I made this quick fix so it doesn't try to find nextPow2 in grig.audio.FFT